### PR TITLE
Fix trailing slash in requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -226,7 +226,11 @@ class Wrapper {
         url += `/${part}.${extension}`
       }
     } else if (part != null) {
-      url += `/${part}`
+      if (part.indexOf('?') === 0) {
+        url += part
+      } else {
+        url += `/${part}`
+      }
     }
     return url
   }


### PR DESCRIPTION
I don't know if anyone else had the same issue but in GET requests trailing slash was added at the end of request and it resulted in 404 for me as this resource didn't exist